### PR TITLE
Sequelize errors now capture stack and messages properly

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,8 +12,10 @@ var error = module.exports = {};
  *
  * @constructor
  */
-error.BaseError = function() {
+error.BaseError = function(message) {
   Error.apply(this, arguments);
+  Error.captureStackTrace(this, this.constructor);
+  this.message = message;
 };
 util.inherits(error.BaseError, Error);
 

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -30,5 +30,14 @@ describe(Support.getTestDialectTeaser("Sequelize Errors"), function () {
       expect(instError).to.be.instanceOf(Error)
       expect(instValidationError).to.be.instanceOf(Error)
     })
+    it('Sequelize Error instances should keep the message and ', function() {
+      var error = new Sequelize.Error('this is the passed message');
+      var validationError = new Sequelize.ValidationError('this is the passed validation message');
+
+      expect(error.message).to.equal('this is the passed message');
+      expect(error.stack).to.exist;
+      expect(validationError.message).to.equal('this is the passed validation message');
+      expect(validationError.stack).to.exist;
+    });
   })
 })


### PR DESCRIPTION
Previously, error messages and stack traces were lost when throwing a custom Sequelize error. This corrects that.

For more details:
http://dailyjs.com/2014/01/30/exception-error/
http://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript
